### PR TITLE
feat: Use HA config as default name, lat, and lon

### DIFF
--- a/custom_components/dwd_precipitation_forecast/config_flow.py
+++ b/custom_components/dwd_precipitation_forecast/config_flow.py
@@ -15,15 +15,6 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-STEP_LOCATION_DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required("name"): str,
-        vol.Required("x"): float,
-        vol.Required("y"): float,
-    }
-)
-
-
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate the user input allows us to connect.
 
@@ -66,7 +57,13 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(title=info["title"], data=user_input)
 
         return self.async_show_form(
-            step_id="user", data_schema=STEP_LOCATION_DATA_SCHEMA, errors=errors
+            step_id="user",
+            data_schema=vol.Schema({
+                vol.Required("name", default=self.hass.config.location_name): str,
+                vol.Required("x", default=self.hass.config.latitude): float,
+                vol.Required("y", default=self.hass.config.longitude): float,
+            }),
+            errors=errors
         )
 
 


### PR DESCRIPTION
Hey!

I just stumbled upon this in the HACS list of new things and I had to install it right away.

While configuring it for the first time, I've noticed that the fields had no defaults.
Given that this forecast will probably be configured for the Home site most of the time, I've added these defaults.

Now the editor spawns with Name, Lat and Lon pre-filled, meaning that setup is just select, click okay, done.


While this still has very little users, I'd also suggest changing x and y to lat and lon, which would be
`CONF_LATITUDE, CONF_LONGITUDE` in `homeassistant.const`